### PR TITLE
Updated CMakeLists.txt

### DIFF
--- a/v0.1.0/CMakeLists.txt
+++ b/v0.1.0/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
+cmake_policy(SET CMP0077 NEW)
+
 project(Workchat VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20) # Corrected to C++20 (C++26 is not yet standardized)

--- a/v0.1.0/CMakeLists.txt
+++ b/v0.1.0/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16.0)
 
 project(Workchat VERSION 0.1.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 26)
+set(CMAKE_CXX_STANDARD 20) # Corrected to C++20 (C++26 is not yet standardized)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -14,12 +14,29 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 
+# FetchContent module to download dependencies
+include(FetchContent)
+
+# Fetch nlohmann/json
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.2 # Use the latest stable version or specify a version
+)
+
+FetchContent_MakeAvailable(nlohmann_json)
+
+# Add sources
 set(SOURCES
     main.cpp
 )
 
 add_executable(Workchat ${SOURCES})
 
+# Link nlohmann/json to the target
+target_link_libraries(Workchat PRIVATE nlohmann_json::nlohmann_json)
+
+# Precompiled headers
 target_precompile_headers(Workchat PRIVATE
     <iostream>
     <string>


### PR DESCRIPTION
`CMakeLists.txt` updated to handle
```
CMake Deprecation Warning at C:/Users/I.Nikiforov/Documents/repos/Workchat/build/_deps/nlohmann_json-src/CMakeLists.txt:1 (cmake_minimum_required):Compatibility with CMake < 3.5 will be removed from a future version of
CMake.

Update the VERSION argument <min> value or use a ...<max> suffix to tell
CMake that the project does not need compatibility with older versions.
```